### PR TITLE
Update Node version and add tigrisdata.com

### DIFF
--- a/package.json
+++ b/package.json
@@ -4,6 +4,10 @@
   "description": "A simple guide to help you get on the Jamstack",
   "version": "0.1.0",
   "license": "MIT",
+  "engineStrict": true,
+  "engines": {
+    "node": "<=16.13.0"
+  },
   "scripts": {
     "develop": "gatsby develop",
     "start": "npm run develop",

--- a/src/components/GettingStarted.js
+++ b/src/components/GettingStarted.js
@@ -222,6 +222,11 @@ export function GettingStarted() {
                 AWS DynamoDB
               </Link>
             </Li>
+            <Li>
+              <Link title="Tigris" href="https://www.tigrisdata.com">
+                Tigris
+              </Link>
+            </Li>
           </Ul>
 
           <SubSectionTitle>Comments</SubSectionTitle>


### PR DESCRIPTION
I had a bit of trouble getting the site to build, so I've updated `package.json` to set an `engines` requirement. I did look into updating packages, but that would take quite some time. Hopefully, this will help others in future.

My motivation for this PR was to add [Tigris](https://www.tigrisdata.com) to the list of DBaaS options. Just a simple update.

![image](https://user-images.githubusercontent.com/328367/212896638-01125582-943e-49cb-a976-4dd40c9a2595.png)
