### PR TITLE
updated links in cms

### DIFF
--- a/src/components/GettingStarted.astro
+++ b/src/components/GettingStarted.astro
@@ -292,9 +292,12 @@
           </li><li>
             <a title="Kontent" href="https://kontent.ai/">Kontent</a>
           </li><li>
-            <a title="GraphCMS" href="https://graphcms.com/">GraphCMS</a>
+            <a title="Hygraph" href="https://hygraph.com/">Hygraph</a>
           </li><li>
             <a title="TakeShape" href="https://www.takeshape.io/">TakeShape</a>
+          </li>
+          <li>
+            <a title="Wisp" href="https://www.wisp.blog/">Wisp</a>
           </li>
         </ul>
       </div>


### PR DESCRIPTION
Updating links in CMS section:

1. Replaced GraphCMS with Hypgraph
2. Included new lightweight CMS, Wisp